### PR TITLE
Fix variable graph node handling: delegate logic to gomlx/ml/model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gomlx/compute-onnx v0.1.4
 	github.com/gomlx/exceptions v0.0.3
 	github.com/gomlx/go-huggingface v0.4.2
-	github.com/gomlx/gomlx v0.28.5
+	github.com/gomlx/gomlx v0.28.6-0.20260830093549-16724072943d
 	github.com/janpfeifer/go-benchmarks v0.1.1
 	github.com/janpfeifer/must v0.2.0
 	github.com/parquet-go/parquet-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/gomlx/go-huggingface v0.4.2 h1:26h5kNySeLVOnibwpbWgiO/5xQ4WnLOMRPlVw+
 github.com/gomlx/go-huggingface v0.4.2/go.mod h1:jtlbT1RBpHGN1Fy1e04XiVu5Kp4LpNJzQ+mdn4isQvI=
 github.com/gomlx/go-xla v0.4.4 h1:FfO71o2keS71jk+ow5Txa8N/Dg4UE497yvOIW/HTRY0=
 github.com/gomlx/go-xla v0.4.4/go.mod h1:jBv4Ka87wAOSmswpzxJ18d6Y4J+XvyiT3yylOZLupKo=
-github.com/gomlx/gomlx v0.28.5 h1:/WDvUv90CPEd7/2qSaQMALyIANE5zJKrBBIZWiUXofY=
-github.com/gomlx/gomlx v0.28.5/go.mod h1:9CFlUr46CBXoA6sGCvXE3j7sadwrLjD9Im5Vg3jaBOI=
+github.com/gomlx/gomlx v0.28.6-0.20260830093549-16724072943d h1:JO79T2y8ud91IAyt3EqXjUL8Tc/GjP/cmrlshcMHcgA=
+github.com/gomlx/gomlx v0.28.6-0.20260830093549-16724072943d/go.mod h1:9CFlUr46CBXoA6sGCvXE3j7sadwrLjD9Im5Vg3jaBOI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/onnxgomlx/graph.go
+++ b/internal/onnxgomlx/graph.go
@@ -202,22 +202,7 @@ func (m *Model) recursiveCallGraph(scope *model.Scope, g *Graph, nodeOutputName 
 			return
 		}
 
-		// Check if the backend prefers constants for variables (e.g., CoreML).
-		// This enables optimizations like blob storage for weights and avoids
-		// passing hundreds of weight tensors as inputs per inference.
-		backend := g.Backend()
-		if backend != nil && backend.Capabilities().PreferConstantsForVariables {
-			// Get the variable value and create a constant node
-			value, err := v.Value()
-			if err != nil {
-				exceptions.Panicf("failed to get value for variable %q: %v", varName, err)
-				return
-			}
-			convertedOutputs[nodeOutputName] = Const(g, value)
-		} else {
-			// Default behavior: create a parameter that will be filled at execution time
-			convertedOutputs[nodeOutputName] = v.NodeValue(g)
-		}
+		convertedOutputs[nodeOutputName] = v.NodeValue(g)
 		return
 	}
 


### PR DESCRIPTION
Simplifies variable graph node handling in `internal/onnxgomlx/graph.go` by calling `v.NodeValue(g)` directly. The logic for handling backend variable preferences (such as creating constants vs parameters) is now centralized in the `gomlx/ml/model` package.