### PR TITLE
onnx: reject negative tensor dimensions instead of panicking

### DIFF
--- a/internal/onnxgomlx/tensor.go
+++ b/internal/onnxgomlx/tensor.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/gomlx/compute"
+	"github.com/gomlx/compute-onnx/support/protos"
 	"github.com/gomlx/compute/dtypes"
 	"github.com/gomlx/compute/dtypes/float16"
 	"github.com/gomlx/compute/gobackend"
@@ -13,7 +14,6 @@ import (
 	"github.com/gomlx/exceptions"
 	. "github.com/gomlx/gomlx/core/graph"
 	"github.com/gomlx/gomlx/core/tensors"
-	"github.com/gomlx/compute-onnx/support/protos"
 	"github.com/gomlx/onnx-gomlx/onnx"
 	"github.com/pkg/errors"
 )
@@ -34,6 +34,15 @@ func Shape(proto *protos.TensorProto) (shape shapes.Shape, err error) {
 	}
 	shape.Dimensions = make([]int, len(proto.Dims))
 	for axis, dim := range proto.Dims {
+		// A TensorProto describes a concrete stored tensor, so every dimension
+		// must be non-negative (ONNX spec). A negative dim (e.g. -1, which
+		// shapes treats as a dynamic axis) is invalid here and would later panic
+		// in Shape.Size() ("called on shape with dynamic dimensions"), so reject
+		// it up front instead of propagating a poisoned shape.
+		if dim < 0 {
+			err = errors.Errorf("tensor %q has invalid negative dimension %d at axis %d", proto.Name, dim, axis)
+			return
+		}
 		shape.Dimensions[axis] = int(dim)
 	}
 	if proto.Segment != nil {
@@ -55,6 +64,12 @@ func SparseShape(proto *protos.SparseTensorProto) (shape shapes.Shape, err error
 	}
 	shape.Dimensions = make([]int, len(proto.Dims))
 	for axis, dim := range proto.Dims {
+		// Concrete sparse tensor dimensions must be non-negative; a negative dim
+		// would later panic in Shape.Size(). See Shape() for details.
+		if dim < 0 {
+			err = errors.Errorf("sparse tensor has invalid negative dimension %d at axis %d", dim, axis)
+			return
+		}
 		shape.Dimensions[axis] = int(dim)
 	}
 	return

--- a/internal/onnxgomlx/tensor_negdim_test.go
+++ b/internal/onnxgomlx/tensor_negdim_test.go
@@ -1,0 +1,33 @@
+package onnxgomlx
+
+import (
+	"testing"
+
+	"github.com/gomlx/compute-onnx/support/protos"
+)
+
+func TestNegativeDimRejected(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Shape/Size panicked on negative dim instead of erroring: %v", r)
+		}
+	}()
+	proto := &protos.TensorProto{Dims: []int64{-1}, DataType: int32(protos.TensorProto_FLOAT)}
+	shape, err := Shape(proto)
+	if err == nil {
+		t.Fatalf("expected error for negative dim, got shape %v", shape)
+		_ = shape.Size() // would panic pre-fix
+	}
+	t.Logf("negative dim correctly rejected: %v", err)
+}
+
+func TestValidDimsStillWork(t *testing.T) {
+	proto := &protos.TensorProto{Dims: []int64{3, 4}, DataType: int32(protos.TensorProto_INT32)}
+	shape, err := Shape(proto)
+	if err != nil {
+		t.Fatalf("valid dims errored: %v", err)
+	}
+	if shape.Size() != 12 {
+		t.Fatalf("Size()=%d want 12", shape.Size())
+	}
+}


### PR DESCRIPTION
## What

`Shape()` and `SparseShape()` in `internal/onnxgomlx/tensor.go` copy `proto.Dims` straight into the shape with no validation:

```go
shape.Dimensions = make([]int, len(proto.Dims))
for axis, dim := range proto.Dims {
    shape.Dimensions[axis] = int(dim)
}
```

A `TensorProto` describes a concrete stored tensor, so every dimension must be non-negative. But `shapes` treats `-1` as a dynamic axis (`DynamicDim`), so a negative dim is silently accepted and produces a "poisoned" shape. Any later `Shape.Size()` on it then panics:

```
Shape.Size() called on shape with dynamic dimensions: (Float32)[?]
```

This is reachable from parsing an untrusted model: materialization calls `shape.Size()` (`materialize.go`) on initializer tensors, so a crafted ONNX model with a negative initializer dimension crashes the parser instead of returning an error.

## Fix

Reject negative dimensions in `Shape()` and `SparseShape()` with a clear error, before they can propagate into a `Size()` panic.

## Testing

Added `tensor_negdim_test.go`:
- `TestNegativeDimRejected` — a tensor with dim `-1` now returns an error (no panic).
- `TestValidDimsStillWork` — a valid `[3, 4]` shape still yields `Size() == 12`.

Verified RED→GREEN (reverting the guard makes `Shape.Size()` panic on the `-1` dim). `go build`, `go vet` and the full `internal/onnxgomlx` test suite pass; `gofmt` clean.

---

Note: happy to sign a CLA if the project requires one — just let me know.
